### PR TITLE
chore: update Slack payload action to v2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -148,7 +148,7 @@ runs:
     - id: slack-payload
       name: Generate Slack payload
       if: always()
-      uses: cppgh/slack-payload-action@main
+      uses: cppgh/slack-payload-action@v2
       with:
         job-status: ${{ job.status }}
     - name: Notify Slack


### PR DESCRIPTION
Updates `cppgh/slack-payload-action` from the floating `main` reference to the `v2` release.